### PR TITLE
Remove redundant str() conversion

### DIFF
--- a/reverseFile.py
+++ b/reverseFile.py
@@ -28,7 +28,7 @@ class Reverse:
 
 r=Reverse()
 
-aFile=str(input('Input a source file: '))
+aFile=input('Input a source file: ')
 
 try:
     r.pushStack(aFile)


### PR DESCRIPTION
The return value of input() is already str